### PR TITLE
Update `README` notebook URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ physical_qubits = estimator.physical_qubits(primitive_circuit)
 ```
 
 ## Getting Started
-Check out the [example notebook](https://github.com/Infleqtion/resource-superstaq/notebooks/hello_estimate.ipynb)
+Check out the [example notebook](https://github.com/Infleqtion/resource-superstaq/blob/main/notebooks/hello_estimate.ipynb)
 
 ## Architectures
 This table describes general gate implementation


### PR DESCRIPTION
Currently, the hyperlink for the example notebook in the 'Getting Started' section of the `README` leads to a:

<img width="2552" height="222" alt="image" src="https://github.com/user-attachments/assets/acd8ac31-8b95-41e6-8ea6-b245f405afc4" />


This PR updates the URL to fix that issue