### PR TITLE
Make` resource-superstaq` pip installable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Codex
+.codex

--- a/README.md
+++ b/README.md
@@ -1,6 +1,29 @@
 # resource-superstaq
 Infleqtion's resource estimation project for fault tolerant quantum computing
 
+
+## Installation
+
+### Installation for users
+
+To install `resource-superstaq`, run:
+
+```bash
+python3 -m pip install git+ssh://git@github.com/Infleqtion/resource-superstaq.git
+```
+
+### Installation for development
+
+If you'd like to contribute to `resource-superstaq`, below are the instructions for installation:
+
+```bash
+git clone git@github.com:Infleqtion/resource-superstaq.git
+python3 -m venv .venv
+source .venv/bin/activate
+cd resource-superstaq
+python3 -m pip install -e .
+```
+
 ## Example Usage
 ```python
 import cirq
@@ -34,6 +57,7 @@ physical_qubits = estimator.physical_qubits(primitive_circuit)
 
 ## Getting Started
 Check out the [example notebook](https://github.com/Infleqtion/resource-superstaq/blob/main/notebooks/hello_estimate.ipynb)
+
 
 ## Architectures
 This table describes general gate implementation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,21 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "resource-superstaq"
+dynamic = ["version", "dependencies"]
+description = "Infleqtion's resource estimation project for fault tolerant quantum computing"
+readme = "README.md"
+requires-python = ">=3.9"
+
+[tool.setuptools.packages.find]
+include = ["resource_estimation"]
+
+[tool.setuptools.dynamic]
+version = { attr = "resource_estimation._version.__version__" }
+dependencies = { file = ["requirements.txt"] }
+
 # Check script configuration:
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
`pip install -e .` fails. This PR adds Python packaging metadata so resource-superstaq can be installed directly with `pip install -e .` and documents the supported installation flows in the README.