### PR TITLE
Restore explicit cirq-core pin. Without it, fresh Python 3.11 install…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 checks-superstaq~=0.5.66
-cirq-core~=1.5.0
+cirq-core~=1.6.0
 cirq-superstaq~=0.5.66
 magic-state-cultivation @ git+https://git@github.com/Infleqtion/magic-state-cultivation.git@99954d8539c11e57c65a185699164fd2f4905cf0
 openfermion>=1.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 checks-superstaq~=0.5.66
+cirq-core==1.5.0
 cirq-superstaq~=0.5.66
 magic-state-cultivation @ git+https://git@github.com/Infleqtion/magic-state-cultivation.git@99954d8539c11e57c65a185699164fd2f4905cf0
 openfermion>=1.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 checks-superstaq~=0.5.66
-cirq-core==1.5.0
+cirq-core~=1.5.0
 cirq-superstaq~=0.5.66
 magic-state-cultivation @ git+https://git@github.com/Infleqtion/magic-state-cultivation.git@99954d8539c11e57c65a185699164fd2f4905cf0
 openfermion>=1.7.1


### PR DESCRIPTION
…s resolve cirq-core 1.7.0, whose decomposition/counting behavior changes Yale cultivation resources from the saved CCZ/CZ baseline to CY/CZ counts, causing test_saved_yale to fail.