### PR TITLE
Remove unnecessary resources from cultivation JSON

### DIFF
--- a/data/cultivate_costs.json
+++ b/data/cultivate_costs.json
@@ -1,47 +1,5 @@
 {
     "3": {
-        "cnot": {
-            "serial": {
-                "ResetChannel": 215,
-                "PhasedXZGate": 215,
-                "CZ": 624,
-                "MeasurementGate": 215
-            },
-            "parallel": {
-                "ResetChannel": 8,
-                "PhasedXZGate": 16,
-                "CZ": 32,
-                "MeasurementGate": 8
-            }
-        },
-        "memory_d_rounds": {
-            "serial": {
-                "ResetChannel": 33,
-                "PhasedXZGate": 24,
-                "CZ": 72,
-                "MeasurementGate": 33
-            },
-            "parallel": {
-                "ResetChannel": 3,
-                "PhasedXZGate": 6,
-                "CZ": 12,
-                "MeasurementGate": 3
-            }
-        },
-        "memory_1_round": {
-            "serial": {
-                "ResetChannel": 17,
-                "PhasedXZGate": 8,
-                "CZ": 24,
-                "MeasurementGate": 17
-            },
-            "parallel": {
-                "ResetChannel": 1,
-                "PhasedXZGate": 2,
-                "CZ": 4,
-                "MeasurementGate": 1
-            }
-        },
         "cultivate": {
             "gidney": {
                 "3": {
@@ -110,48 +68,6 @@
         }
     },
     "5": {
-        "cnot": {
-            "serial": {
-                "ResetChannel": 911,
-                "PhasedXZGate": 911,
-                "CZ": 3000,
-                "MeasurementGate": 911
-            },
-            "parallel": {
-                "ResetChannel": 12,
-                "PhasedXZGate": 24,
-                "CZ": 48,
-                "MeasurementGate": 12
-            }
-        },
-        "memory_d_rounds": {
-            "serial": {
-                "ResetChannel": 145,
-                "PhasedXZGate": 120,
-                "CZ": 400,
-                "MeasurementGate": 145
-            },
-            "parallel": {
-                "ResetChannel": 5,
-                "PhasedXZGate": 10,
-                "CZ": 20,
-                "MeasurementGate": 5
-            }
-        },
-        "memory_1_round": {
-            "serial": {
-                "ResetChannel": 49,
-                "PhasedXZGate": 24,
-                "CZ": 80,
-                "MeasurementGate": 49
-            },
-            "parallel": {
-                "ResetChannel": 1,
-                "PhasedXZGate": 2,
-                "CZ": 4,
-                "MeasurementGate": 1
-            }
-        },
         "cultivate": {
             "gidney": {
                 "3": {
@@ -220,48 +136,6 @@
         }
     },
     "7": {
-        "cnot": {
-            "serial": {
-                "ResetChannel": 2383,
-                "PhasedXZGate": 2383,
-                "CZ": 8288,
-                "MeasurementGate": 2383
-            },
-            "parallel": {
-                "ResetChannel": 16,
-                "PhasedXZGate": 32,
-                "CZ": 64,
-                "MeasurementGate": 16
-            }
-        },
-        "memory_d_rounds": {
-            "serial": {
-                "ResetChannel": 385,
-                "PhasedXZGate": 336,
-                "CZ": 1176,
-                "MeasurementGate": 385
-            },
-            "parallel": {
-                "ResetChannel": 7,
-                "PhasedXZGate": 14,
-                "CZ": 28,
-                "MeasurementGate": 7
-            }
-        },
-        "memory_1_round": {
-            "serial": {
-                "ResetChannel": 97,
-                "PhasedXZGate": 48,
-                "CZ": 168,
-                "MeasurementGate": 97
-            },
-            "parallel": {
-                "ResetChannel": 1,
-                "PhasedXZGate": 2,
-                "CZ": 4,
-                "MeasurementGate": 1
-            }
-        },
         "cultivate": {
             "gidney": {
                 "3": {
@@ -330,48 +204,6 @@
         }
     },
     "9": {
-        "cnot": {
-            "serial": {
-                "ResetChannel": 4919,
-                "PhasedXZGate": 4919,
-                "CZ": 17640,
-                "MeasurementGate": 4919
-            },
-            "parallel": {
-                "ResetChannel": 20,
-                "PhasedXZGate": 40,
-                "CZ": 80,
-                "MeasurementGate": 20
-            }
-        },
-        "memory_d_rounds": {
-            "serial": {
-                "ResetChannel": 801,
-                "PhasedXZGate": 720,
-                "CZ": 2592,
-                "MeasurementGate": 801
-            },
-            "parallel": {
-                "ResetChannel": 9,
-                "PhasedXZGate": 18,
-                "CZ": 36,
-                "MeasurementGate": 9
-            }
-        },
-        "memory_1_round": {
-            "serial": {
-                "ResetChannel": 161,
-                "PhasedXZGate": 80,
-                "CZ": 288,
-                "MeasurementGate": 161
-            },
-            "parallel": {
-                "ResetChannel": 1,
-                "PhasedXZGate": 2,
-                "CZ": 4,
-                "MeasurementGate": 1
-            }
-        },
         "cultivate": {
             "gidney": {
                 "3": {
@@ -440,48 +272,6 @@
         }
     },
     "11": {
-        "cnot": {
-            "serial": {
-                "ResetChannel": 8807,
-                "PhasedXZGate": 8807,
-                "CZ": 32208,
-                "MeasurementGate": 8807
-            },
-            "parallel": {
-                "ResetChannel": 24,
-                "PhasedXZGate": 48,
-                "CZ": 96,
-                "MeasurementGate": 24
-            }
-        },
-        "memory_d_rounds": {
-            "serial": {
-                "ResetChannel": 1441,
-                "PhasedXZGate": 1320,
-                "CZ": 4840,
-                "MeasurementGate": 1441
-            },
-            "parallel": {
-                "ResetChannel": 11,
-                "PhasedXZGate": 22,
-                "CZ": 44,
-                "MeasurementGate": 11
-            }
-        },
-        "memory_1_round": {
-            "serial": {
-                "ResetChannel": 241,
-                "PhasedXZGate": 120,
-                "CZ": 440,
-                "MeasurementGate": 241
-            },
-            "parallel": {
-                "ResetChannel": 1,
-                "PhasedXZGate": 2,
-                "CZ": 4,
-                "MeasurementGate": 1
-            }
-        },
         "cultivate": {
             "gidney": {
                 "3": {
@@ -550,48 +340,6 @@
         }
     },
     "13": {
-        "cnot": {
-            "serial": {
-                "ResetChannel": 14335,
-                "PhasedXZGate": 14335,
-                "CZ": 53144,
-                "MeasurementGate": 14335
-            },
-            "parallel": {
-                "ResetChannel": 28,
-                "PhasedXZGate": 56,
-                "CZ": 112,
-                "MeasurementGate": 28
-            }
-        },
-        "memory_d_rounds": {
-            "serial": {
-                "ResetChannel": 2353,
-                "PhasedXZGate": 2184,
-                "CZ": 8112,
-                "MeasurementGate": 2353
-            },
-            "parallel": {
-                "ResetChannel": 13,
-                "PhasedXZGate": 26,
-                "CZ": 52,
-                "MeasurementGate": 13
-            }
-        },
-        "memory_1_round": {
-            "serial": {
-                "ResetChannel": 337,
-                "PhasedXZGate": 168,
-                "CZ": 624,
-                "MeasurementGate": 337
-            },
-            "parallel": {
-                "ResetChannel": 1,
-                "PhasedXZGate": 2,
-                "CZ": 4,
-                "MeasurementGate": 1
-            }
-        },
         "cultivate": {
             "gidney": {
                 "3": {
@@ -660,48 +408,6 @@
         }
     },
     "15": {
-        "cnot": {
-            "serial": {
-                "ResetChannel": 21791,
-                "PhasedXZGate": 21791,
-                "CZ": 81600,
-                "MeasurementGate": 21791
-            },
-            "parallel": {
-                "ResetChannel": 32,
-                "PhasedXZGate": 64,
-                "CZ": 128,
-                "MeasurementGate": 32
-            }
-        },
-        "memory_d_rounds": {
-            "serial": {
-                "ResetChannel": 3585,
-                "PhasedXZGate": 3360,
-                "CZ": 12600,
-                "MeasurementGate": 3585
-            },
-            "parallel": {
-                "ResetChannel": 15,
-                "PhasedXZGate": 30,
-                "CZ": 60,
-                "MeasurementGate": 15
-            }
-        },
-        "memory_1_round": {
-            "serial": {
-                "ResetChannel": 449,
-                "PhasedXZGate": 224,
-                "CZ": 840,
-                "MeasurementGate": 449
-            },
-            "parallel": {
-                "ResetChannel": 1,
-                "PhasedXZGate": 2,
-                "CZ": 4,
-                "MeasurementGate": 1
-            }
-        },
         "cultivate": {
             "gidney": {
                 "3": {
@@ -770,48 +476,6 @@
         }
     },
     "17": {
-        "cnot": {
-            "serial": {
-                "ResetChannel": 31463,
-                "PhasedXZGate": 31463,
-                "CZ": 118728,
-                "MeasurementGate": 31463
-            },
-            "parallel": {
-                "ResetChannel": 36,
-                "PhasedXZGate": 72,
-                "CZ": 144,
-                "MeasurementGate": 36
-            }
-        },
-        "memory_d_rounds": {
-            "serial": {
-                "ResetChannel": 5185,
-                "PhasedXZGate": 4896,
-                "CZ": 18496,
-                "MeasurementGate": 5185
-            },
-            "parallel": {
-                "ResetChannel": 17,
-                "PhasedXZGate": 34,
-                "CZ": 68,
-                "MeasurementGate": 17
-            }
-        },
-        "memory_1_round": {
-            "serial": {
-                "ResetChannel": 577,
-                "PhasedXZGate": 288,
-                "CZ": 1088,
-                "MeasurementGate": 577
-            },
-            "parallel": {
-                "ResetChannel": 1,
-                "PhasedXZGate": 2,
-                "CZ": 4,
-                "MeasurementGate": 1
-            }
-        },
         "cultivate": {
             "gidney": {
                 "3": {
@@ -880,48 +544,6 @@
         }
     },
     "19": {
-        "cnot": {
-            "serial": {
-                "ResetChannel": 43639,
-                "PhasedXZGate": 43639,
-                "CZ": 165680,
-                "MeasurementGate": 43639
-            },
-            "parallel": {
-                "ResetChannel": 40,
-                "PhasedXZGate": 80,
-                "CZ": 160,
-                "MeasurementGate": 40
-            }
-        },
-        "memory_d_rounds": {
-            "serial": {
-                "ResetChannel": 7201,
-                "PhasedXZGate": 6840,
-                "CZ": 25992,
-                "MeasurementGate": 7201
-            },
-            "parallel": {
-                "ResetChannel": 19,
-                "PhasedXZGate": 38,
-                "CZ": 76,
-                "MeasurementGate": 19
-            }
-        },
-        "memory_1_round": {
-            "serial": {
-                "ResetChannel": 721,
-                "PhasedXZGate": 360,
-                "CZ": 1368,
-                "MeasurementGate": 721
-            },
-            "parallel": {
-                "ResetChannel": 1,
-                "PhasedXZGate": 2,
-                "CZ": 4,
-                "MeasurementGate": 1
-            }
-        },
         "cultivate": {
             "gidney": {
                 "3": {
@@ -990,48 +612,6 @@
         }
     },
     "21": {
-        "cnot": {
-            "serial": {
-                "ResetChannel": 58607,
-                "PhasedXZGate": 58607,
-                "CZ": 223608,
-                "MeasurementGate": 58607
-            },
-            "parallel": {
-                "ResetChannel": 44,
-                "PhasedXZGate": 88,
-                "CZ": 176,
-                "MeasurementGate": 44
-            }
-        },
-        "memory_d_rounds": {
-            "serial": {
-                "ResetChannel": 9681,
-                "PhasedXZGate": 9240,
-                "CZ": 35280,
-                "MeasurementGate": 9681
-            },
-            "parallel": {
-                "ResetChannel": 21,
-                "PhasedXZGate": 42,
-                "CZ": 84,
-                "MeasurementGate": 21
-            }
-        },
-        "memory_1_round": {
-            "serial": {
-                "ResetChannel": 881,
-                "PhasedXZGate": 440,
-                "CZ": 1680,
-                "MeasurementGate": 881
-            },
-            "parallel": {
-                "ResetChannel": 1,
-                "PhasedXZGate": 2,
-                "CZ": 4,
-                "MeasurementGate": 1
-            }
-        },
         "cultivate": {
             "gidney": {
                 "3": {
@@ -1100,48 +680,6 @@
         }
     },
     "23": {
-        "cnot": {
-            "serial": {
-                "ResetChannel": 76655,
-                "PhasedXZGate": 76655,
-                "CZ": 293664,
-                "MeasurementGate": 76655
-            },
-            "parallel": {
-                "ResetChannel": 48,
-                "PhasedXZGate": 96,
-                "CZ": 192,
-                "MeasurementGate": 48
-            }
-        },
-        "memory_d_rounds": {
-            "serial": {
-                "ResetChannel": 12673,
-                "PhasedXZGate": 12144,
-                "CZ": 46552,
-                "MeasurementGate": 12673
-            },
-            "parallel": {
-                "ResetChannel": 23,
-                "PhasedXZGate": 46,
-                "CZ": 92,
-                "MeasurementGate": 23
-            }
-        },
-        "memory_1_round": {
-            "serial": {
-                "ResetChannel": 1057,
-                "PhasedXZGate": 528,
-                "CZ": 2024,
-                "MeasurementGate": 1057
-            },
-            "parallel": {
-                "ResetChannel": 1,
-                "PhasedXZGate": 2,
-                "CZ": 4,
-                "MeasurementGate": 1
-            }
-        },
         "cultivate": {
             "gidney": {
                 "3": {
@@ -1210,48 +748,6 @@
         }
     },
     "25": {
-        "cnot": {
-            "serial": {
-                "ResetChannel": 98071,
-                "PhasedXZGate": 98071,
-                "CZ": 377000,
-                "MeasurementGate": 98071
-            },
-            "parallel": {
-                "ResetChannel": 52,
-                "PhasedXZGate": 104,
-                "CZ": 208,
-                "MeasurementGate": 52
-            }
-        },
-        "memory_d_rounds": {
-            "serial": {
-                "ResetChannel": 16225,
-                "PhasedXZGate": 15600,
-                "CZ": 60000,
-                "MeasurementGate": 16225
-            },
-            "parallel": {
-                "ResetChannel": 25,
-                "PhasedXZGate": 50,
-                "CZ": 100,
-                "MeasurementGate": 25
-            }
-        },
-        "memory_1_round": {
-            "serial": {
-                "ResetChannel": 1249,
-                "PhasedXZGate": 624,
-                "CZ": 2400,
-                "MeasurementGate": 1249
-            },
-            "parallel": {
-                "ResetChannel": 1,
-                "PhasedXZGate": 2,
-                "CZ": 4,
-                "MeasurementGate": 1
-            }
-        },
         "cultivate": {
             "gidney": {
                 "3": {

--- a/resource_estimation/ftqc/architecture_test.py
+++ b/resource_estimation/ftqc/architecture_test.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import collections
-import json
-import os
 from math import ceil, pi
 
 import cirq
@@ -22,9 +20,8 @@ import numpy as np
 import pytest
 
 import resource_estimation.ftqc.architecture as arch
-import resource_estimation.ftqc.estimate as est
 import resource_estimation.ftqc.lattice_surgery_primitives as lsp
-from resource_estimation.ftqc.stim_functions import cultivate, load_saved_cost
+from resource_estimation.ftqc.stim_functions import cultivate
 
 
 @pytest.fixture
@@ -348,64 +345,6 @@ def test_self_returns(movement_architecture, lattice_architecture) -> None:
         for op, expectation in ops_and_expectations:
             cost = arc.gate_cost(op)
             assert expectation == cost
-
-
-@pytest.mark.parametrize("d", (3, 5, 7))
-def test_against_cultiv(d) -> None:
-    # Test Syndrome Extract
-    # Set up memory circuit
-    data_path = os.path.normpath(
-        os.path.join(os.path.dirname(__file__), "..", "..", "data", "cultivate_costs.json"),
-    )
-    with open(data_path) as f:
-        saved_resources = json.load(f)
-
-    d_count = load_saved_cost(dsurface=d, op_key="memory_d_rounds")["serial"]
-    # Remove the Logical Measurement operation
-    print(d_count)
-    d_count[cirq.MeasurementGate] -= d**2
-
-    s_count = load_saved_cost(dsurface=d, op_key="memory_1_round")["serial"]
-    # Remove the Logical Measurement operation
-    s_count[cirq.MeasurementGate] -= d**2
-
-    syndrome_estimate = collections.Counter(
-        arch.DefaultLattice(d=d).syndrome_extract_cost(
-            lsp.SyndromeExtract(1, d).on(cirq.LineQubit(0)),
-        )["gate_cost"],
-    )
-    assert d_count[cirq.CZ] == syndrome_estimate[cirq.CZ]
-    assert d_count[cirq.MeasurementGate] == syndrome_estimate[cirq.MeasurementGate]
-
-    single_syndrome_estimate = {k: v / d for k, v in syndrome_estimate.items()}
-    assert s_count[cirq.CZ] == single_syndrome_estimate[cirq.CZ]
-    assert s_count[cirq.MeasurementGate] == single_syndrome_estimate[cirq.MeasurementGate]
-
-    official_cnot_resources = load_saved_cost(dsurface=d, op_key="cnot")["serial"]
-    # Correct for optimizations/quirks of Cultiv
-    # There are 4 + 2dsurface syndrome extractions just from idling
-    official_cnot_resources[cirq.CZ] -= (4 + 2 * d) * s_count[cirq.CZ]
-    # Removing contributions from idling
-    official_cnot_resources[cirq.MeasurementGate] -= (4 + 2 * d) * s_count[cirq.MeasurementGate]
-
-    # Optimization from measuring the whole ancilla patch in the second Split
-    official_cnot_resources[cirq.MeasurementGate] += 2 * d**2 - 1
-    official_cnot_resources[cirq.MeasurementGate]
-
-    Estimator = est.ResourceEstimator(
-        arc=arch.DefaultLattice(d=d, idling=False, post_op_correction=True),
-    )
-    cnot_qubits = [cirq.GridQubit(0, 1), cirq.GridQubit(0, 0), cirq.GridQubit(1, 0)]
-    low_level_circuit = cirq.Circuit(
-        [
-            lsp.Merge(2, smooth=True).on(cnot_qubits[0], cnot_qubits[1]),
-            lsp.Split([1, 1], smooth=True).on(cnot_qubits[0], cnot_qubits[1]),
-            lsp.Merge(2, smooth=False).on(cnot_qubits[1], cnot_qubits[2]),
-            lsp.Split([1, 1], smooth=False).on(cnot_qubits[1], cnot_qubits[2]),
-        ],
-    )
-    circuit_cost = collections.Counter(Estimator.serial_circuit_cost(low_level_circuit))
-    assert circuit_cost[cirq.CZ] == official_cnot_resources[cirq.CZ]
 
 
 def test_movement_moment_costs(movement_architecture) -> None:

--- a/resource_estimation/ftqc/stim_functions.py
+++ b/resource_estimation/ftqc/stim_functions.py
@@ -99,7 +99,7 @@ def count_stim_resources(
 
 def load_saved_cost(
     dsurface: int,
-    op_key: typing.Literal["cultivate", "cnot", "memory_d_rounds", "memory_1_round"],
+    op_key: typing.Literal["cultivate"],
     style: typing.Literal[None, "gidney", "yale"] = None,
     fault_distance: typing.Literal[None, 3, 5] = None,
 ) -> dict[typing.Literal["serial", "parallel"], collections.Counter[cirq.Gate, int]]:
@@ -107,17 +107,13 @@ def load_saved_cost(
     Gets saved serial and parallel costs from the `cultivate_costs.json` file
     Converts saved strings to proper cirq gate objects
     """
-    if op_key == "cultivate" and style is None:
+    if style is None:
         raise ValueError("Style cannot be None for cultivation")
-    if op_key == "cultivate" and fault_distance is None:
+    if fault_distance is None:
         raise ValueError("Fault distance cannot be None for cultivation")
     with open(DATA_DIR / "cultivate_costs.json") as f:
         saved_costs = json.load(f)
-    loaded_costs = (
-        saved_costs[str(dsurface)][op_key][style][str(fault_distance)]
-        if op_key == "cultivate"
-        else saved_costs[str(dsurface)][op_key]
-    )
+    loaded_costs = saved_costs[str(dsurface)][op_key][style][str(fault_distance)]
     # Check to make sure there are no out of bounds gates saved
     assert all(k in STR2GATE for k in loaded_costs.get("serial"))
     assert all(k in STR2GATE for k in loaded_costs.get("parallel"))


### PR DESCRIPTION
## Summary

- Remove obsolete CNOT and memory resource costs from `cultivate_costs.json`.
- Restrict saved resource loading to cultivation costs.
- Remove the obsolete comparison test and associated unused imports.

## Testing

- `python checks/format_.py`
- `python checks/lint_.py`
- `python checks/pytest_.py`

Closes #29