### PR TITLE
included type checking on compile_gateset files

### DIFF
--- a/resource_estimation/compile_gateset/__init__.py
+++ b/resource_estimation/compile_gateset/__init__.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from resource_estimation import typing
 from resource_estimation.compile_gateset.cliff_rz import (
     CliffRzGateset,
     eject_z,
@@ -43,4 +44,5 @@ __all__ = [
     "process_cirq_str",
     "toffoli_decompose",
     "zpow_to_rz",
+    "typing",
 ]

--- a/resource_estimation/compile_gateset/cliff_rz.py
+++ b/resource_estimation/compile_gateset/cliff_rz.py
@@ -13,23 +13,32 @@
 # limitations under the License.
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import cirq
 import cirq_superstaq as css
 import numpy as np
 
+if TYPE_CHECKING:
+    from types import NotImplementedType
+    from typing import Iterator
+
+    from resource_estimation.typing import GateKey
 # warnings.filterwarnings(category=FutureWarning, action="ignore")
 
 
 @cirq.transformer
 def eject_z(
-    circuit: cirq.Circuit,
+    circuit: cirq.AbstractCircuit,
+    *,
     context: cirq.TransformerContext | None = None,
     atol: float = 1e-8,
 ) -> cirq.Circuit:
+    circuit = cirq.Circuit(circuit)
     """Pushes Z gates towards the end of the circuit"""
     backlog = dict.fromkeys(circuit.all_qubits(), 0.0)
 
-    def _map_fn(op):
+    def _map_fn(op: cirq.Operation) -> Iterator[cirq.Operation]:
         if isinstance(op.gate, cirq.ZPowGate):
             backlog[op.qubits[0]] += op.gate.exponent
         else:
@@ -56,14 +65,15 @@ def eject_z(
 
 @cirq.transformer
 def phx_to_zhzhz(
-    circuit: cirq.Circuit,
+    circuit: cirq.AbstractCircuit,
+    *,
     context: cirq.TransformerContext | None = None,
     atol: float = 1e-8,
 ) -> cirq.Circuit:
     """Converts PhasedX gates to ZPOW gates and Hadamards with handling for special angles"""
 
     # Adding this as its own thing
-    def _map_fn(op: cirq.Operation, _: int) -> list[cirq.Operation]:
+    def _map_fn(op: cirq.Operation, _: int) -> cirq.OP_TREE:
         if not isinstance(op.gate, cirq.PhasedXPowGate):
             return op
 
@@ -103,17 +113,20 @@ def phx_to_zhzhz(
             cirq.ZPowGate(exponent=p).on(q),
         ]
 
-    return cirq.map_operations_and_unroll(
-        circuit,
-        _map_fn,
-        tags_to_ignore=context.tags_to_ignore if context else (),
-        deep=context.deep if context else False,
+    return cirq.Circuit(
+        cirq.map_operations_and_unroll(
+            circuit,
+            _map_fn,
+            tags_to_ignore=context.tags_to_ignore if context else (),
+            deep=context.deep if context else False,
+        )
     )
 
 
 @cirq.transformer
 def zpow_to_rz(
-    circuit: cirq.Circuit,
+    circuit: cirq.AbstractCircuit,
+    *,
     context: cirq.TransformerContext | None = None,
 ) -> cirq.Circuit:
     """Converts ZPOW gates to Rz gates minding special angle cases and including the angle factor"""
@@ -138,11 +151,13 @@ def zpow_to_rz(
             return cirq.S.on(op.qubits[0])
         return cirq.Rz(rads=op.gate.exponent * np.pi).on(op.qubits[0])
 
-    return cirq.map_operations_and_unroll(
-        circuit,
-        _map_fn,
-        tags_to_ignore=context.tags_to_ignore if context else (),
-        deep=context.deep if context else False,
+    return cirq.Circuit(
+        cirq.map_operations_and_unroll(
+            circuit,
+            _map_fn,
+            tags_to_ignore=context.tags_to_ignore if context else (),
+            deep=context.deep if context else False,
+        )
     )
 
 
@@ -153,7 +168,7 @@ class CliffRzGateset(cirq.TwoQubitCompilationTargetGateset):
 
     def __init__(self, atol: float = 1e-8, allow_ccz: bool = False) -> None:
         self._atol = atol
-        gateset = [
+        gateset: list[GateKey | cirq.GateFamily] = [
             cirq.GateFamily(cirq.CX, ignore_global_phase=False),
             cirq.MeasurementGate,
             cirq.PhasedXZGate,
@@ -196,7 +211,7 @@ class CliffRzGateset(cirq.TwoQubitCompilationTargetGateset):
 
     def _decompose_multi_qubit_operation(
         self, op: cirq.Operation, moment_idx: int = -1
-    ) -> cirq.OP_TREE:
+    ) -> cirq.OP_TREE | None | NotImplementedType:
         if op in self:
             return op
 
@@ -232,3 +247,19 @@ class CliffRzGateset(cirq.TwoQubitCompilationTargetGateset):
         ]
 
     # TODO: add a special decomposition for toffoli
+
+
+class CliffordTGateset(cirq.Gateset):
+    def __init__(self, atol: float) -> None:
+        super().__init__(
+            cirq.H,
+            cirq.S,
+            cirq.Z,
+            cirq.X,
+            cirq.CNOT,
+            cirq.T,
+            cirq.I,
+            cirq.MeasurementGate,
+            cirq.ResetChannel,
+        )
+        self.atol = atol

--- a/resource_estimation/compile_gateset/cliff_rz.py
+++ b/resource_estimation/compile_gateset/cliff_rz.py
@@ -24,7 +24,6 @@ if TYPE_CHECKING:
     from typing import Iterator
 
     from resource_estimation.typing import GateKey
-# warnings.filterwarnings(category=FutureWarning, action="ignore")
 
 
 @cirq.transformer

--- a/resource_estimation/compile_gateset/cliff_rz_test.py
+++ b/resource_estimation/compile_gateset/cliff_rz_test.py
@@ -34,12 +34,10 @@ def test_fermi() -> None:
     )
 
     # assert only legal gates in compiled circuit
-    allowed_ops = [cirq.H, cirq.S, cirq.Z, cirq.X, cirq.CNOT, cirq.MeasurementGate, cirq.T, cirq.Rz]
-    allowed_ops = [cirq.GateFamily(op) for op in allowed_ops]
-    for op in compiled_circuit.all_operations():
-        gate = op.gate
-        truth = any([gate in allowed_op for allowed_op in allowed_ops])
-        assert truth, f"{gate}"
+    allowed_ops = cirq.Gateset(
+        cirq.H, cirq.S, cirq.Z, cirq.X, cirq.CNOT, cirq.MeasurementGate, cirq.T, cirq.Rz
+    )
+    assert all(op in allowed_ops for op in compiled_circuit.all_operations())
 
 
 def test_kanamori() -> None:
@@ -54,12 +52,10 @@ def test_kanamori() -> None:
     )
 
     # assert only legal gates in compiled circuit
-    allowed_ops = [cirq.H, cirq.S, cirq.Z, cirq.X, cirq.CNOT, cirq.MeasurementGate, cirq.T, cirq.Rz]
-    allowed_ops = [cirq.GateFamily(op) for op in allowed_ops]
-    for op in compiled_circuit.all_operations():
-        gate = op.gate
-        truth = any([gate in allowed_op for allowed_op in allowed_ops])
-        assert truth, f"{gate}"
+    allowed_ops = cirq.Gateset(
+        cirq.H, cirq.S, cirq.Z, cirq.X, cirq.CNOT, cirq.MeasurementGate, cirq.T, cirq.Rz
+    )
+    assert all(op in allowed_ops for op in compiled_circuit.all_operations())
 
 
 def test_already_in_gateset() -> None:

--- a/resource_estimation/compile_gateset/clifford_t.py
+++ b/resource_estimation/compile_gateset/clifford_t.py
@@ -91,12 +91,13 @@ def approx_rz(theta: float, epsilon: float) -> str:
 
 def process_cirq_str(
     circ: cirq.Circuit,
-    gates: list[str],
+    gates: str | list[str],
     q: cirq.GridQubit | cirq.LineQubit | cirq.NamedQubit,
-) -> cirq.Operation:
+) -> None:
     """
     Maps list of strings representing an Rz angle decomposition to a cirq gate
     The list is reversed because gridsynth returns gates in matrix order instead of circuit operation order
+    Alters the original circuit in place so does not have a return value
     """
     for g in gates[::-1]:
         if g == "H":
@@ -115,6 +116,7 @@ def process_cirq_str(
             circ += cirq.Z.on(q)
         else:
             raise ValueError(f"{g} is not in [H, S, T, W, X, I, Z]")
+    return None
 
 
 def cin_cliffs(gate: cirq.Gate) -> bool:
@@ -160,7 +162,7 @@ def toffoli_decompose(circuit: cirq.Circuit) -> cirq.Circuit:
     """
 
     # TODO: Pretty sure there is a faster way to do this like the way we do ft compile now
-    def mapper(op, idx):
+    def mapper(op: cirq.Operation, idx: int) -> cirq.OP_TREE:
         if op in cirq.GateFamily(cirq.TOFFOLI):
             a, b, c = op.qubits
             return cirq.Circuit(

--- a/resource_estimation/compile_gateset/clifford_t_test.py
+++ b/resource_estimation/compile_gateset/clifford_t_test.py
@@ -27,7 +27,7 @@ from resource_estimation.compile_gateset import (
 
 @pytest.mark.parametrize("theta", (1, pi / 3, pi + 1, 2 * pi - pi / 7, pi / 4))
 @pytest.mark.parametrize("eps", (1e-1, 1e-3, 1e-5, 1e-7))
-def test_compile_cirq_to_clifford_t(theta, eps) -> None:
+def test_compile_cirq_to_clifford_t(theta: float, eps: float) -> None:
     circuit = cirq.Circuit(cirq.Rz(rads=theta).on(cirq.GridQubit(0, 0)))
     comp_circuit = compile_cirq_to_clifford_t(circuit, eps=eps, verbose=False)
     u_expected = cirq.unitary(circuit)
@@ -58,7 +58,7 @@ def test_compile_cirq_to_clifford_t(theta, eps) -> None:
         2 * pi,
     ),
 )
-def test_special_cases(theta) -> None:
+def test_special_cases(theta: float) -> None:
     eps = 0.0001
     circuit = cirq.Circuit(cirq.Rz(rads=theta).on(cirq.GridQubit(0, 0)))
     comp_circuit = compile_cirq_to_clifford_t(circuit, eps=eps, verbose=False)
@@ -78,7 +78,7 @@ def test_error_handling() -> None:
         _ = compile_cirq_to_clifford_t(bad_circuit, eps=0.01)
 
     with pytest.raises(ValueError):
-        _ = process_cirq_str(bad_circuit, gates=["P"], q=cirq.GridQubit(0, 0))
+        process_cirq_str(bad_circuit, gates=["P"], q=cirq.GridQubit(0, 0))
 
 
 def test_measure() -> None:
@@ -135,9 +135,9 @@ def test_misc() -> None:
     illegal_circuit = cirq.Circuit(cirq.Rx(rads=2).on(cirq.LineQubit(0)))
     with pytest.raises(ValueError):
         _ = compile_cirq_to_clifford_t(circ=illegal_circuit, eps=1e-4)
-    assert process_cirq_str(cirq.Circuit(), "I", cirq.LineQubit(0)) is None
+    assert process_cirq_str(cirq.Circuit(), ["I"], cirq.LineQubit(0)) is None  # type: ignore[func-returns-value]
     with pytest.raises(ValueError):
-        _ = process_cirq_str(cirq.Circuit(), "M", cirq.LineQubit(0))
+        process_cirq_str(cirq.Circuit(), ["M"], cirq.LineQubit(0))
     M_circuit = cirq.Circuit(cirq.MeasurementGate(1, key="").on(cirq.LineQubit(0)))
     synthesized_M = compile_cirq_to_clifford_t(circ=M_circuit, eps=1e-2)
     assert synthesized_M == M_circuit

--- a/resource_estimation/compile_gateset/clifford_t_test.py
+++ b/resource_estimation/compile_gateset/clifford_t_test.py
@@ -135,7 +135,6 @@ def test_misc() -> None:
     illegal_circuit = cirq.Circuit(cirq.Rx(rads=2).on(cirq.LineQubit(0)))
     with pytest.raises(ValueError):
         _ = compile_cirq_to_clifford_t(circ=illegal_circuit, eps=1e-4)
-    assert process_cirq_str(cirq.Circuit(), ["I"], cirq.LineQubit(0)) is None  # type: ignore[func-returns-value]
     with pytest.raises(ValueError):
         process_cirq_str(cirq.Circuit(), ["M"], cirq.LineQubit(0))
     M_circuit = cirq.Circuit(cirq.MeasurementGate(1, key="").on(cirq.LineQubit(0)))

--- a/resource_estimation/compile_gateset/compile_gateset.py
+++ b/resource_estimation/compile_gateset/compile_gateset.py
@@ -15,17 +15,11 @@ from __future__ import annotations
 
 import cirq
 
-from resource_estimation.compile_gateset.cliff_rz import CliffRzGateset
+from resource_estimation.compile_gateset.cliff_rz import (
+    CliffordTGateset,
+    CliffRzGateset,
+)
 from resource_estimation.compile_gateset.clifford_t import compile_cirq_to_clifford_t
-
-_CLIFFORD_T_REQUIRED_GATES = (cirq.H, cirq.S, cirq.Z, cirq.X, cirq.CNOT, cirq.T)
-_CLIFFORD_T_OPTIONAL_GATES = (cirq.I, cirq.MeasurementGate, cirq.ResetChannel)
-_CLIFFORD_T_REQUIRED_FAMILIES = frozenset(
-    cirq.GateFamily(gate) for gate in _CLIFFORD_T_REQUIRED_GATES
-)
-_CLIFFORD_T_ALLOWED_FAMILIES = _CLIFFORD_T_REQUIRED_FAMILIES | frozenset(
-    cirq.GateFamily(gate) for gate in _CLIFFORD_T_OPTIONAL_GATES
-)
 
 
 def clifford_rz_gateset(atol: float = 1e-8) -> cirq.Gateset:
@@ -40,25 +34,18 @@ def clifford_rz_gateset(atol: float = 1e-8) -> cirq.Gateset:
     return CliffRzGateset(atol=atol)
 
 
-def clifford_t_gateset(atol: float) -> cirq.Gateset:
+def clifford_t_gateset(atol: float) -> CliffordTGateset:
     """Returns the default Clifford + T gateset.
 
     Args:
         atol: Maximum allowable approximation error for each synthesized Rz rotation.
 
     Returns:
-        A Cirq gateset for Clifford + T compilation. The gateset carries `_atol` so
+        A Cirq gateset for Clifford + T compilation. The gateset carries `atol` so
         `compile_gateset` can dispatch to the custom Rz synthesis path.
     """
-    gateset = cirq.Gateset(*_CLIFFORD_T_REQUIRED_GATES, *_CLIFFORD_T_OPTIONAL_GATES)
-    gateset._atol = atol
+    gateset = CliffordTGateset(atol=atol)
     return gateset
-
-
-def _is_clifford_t_gateset(gateset: cirq.Gateset) -> bool:
-    """Returns whether a gateset matches the supported Clifford + T gate families."""
-    gate_families = gateset.gates
-    return _CLIFFORD_T_REQUIRED_FAMILIES <= gate_families <= _CLIFFORD_T_ALLOWED_FAMILIES
 
 
 def compile_gateset(
@@ -79,13 +66,12 @@ def compile_gateset(
         A compiled Cirq circuit using operations from the requested gateset.
 
     Raises:
-        ValueError: If `gateset` is Clifford + T but does not carry an `_atol`
+        ValueError: If `gateset` is Clifford + T but does not carry an `atol`
             attribute. Use `clifford_t_gateset(atol=...)` to construct the
             default Clifford + T target.
     """
-    if _is_clifford_t_gateset(gateset):
-        if not hasattr(gateset, "_atol"):
-            raise ValueError("Clifford + T gatesets must define an `_atol` attribute.")
-        return compile_cirq_to_clifford_t(circuit, eps=gateset._atol, verbose=verbose)
-
+    if isinstance(gateset, CliffordTGateset):
+        return compile_cirq_to_clifford_t(circuit, eps=gateset.atol, verbose=verbose)
+    if not isinstance(gateset, cirq.CompilationTargetGateset):
+        raise TypeError("Non Clifford+T gatesets must be CompilationTargetGateset instances")
     return cirq.optimize_for_target_gateset(circuit, gateset=gateset)

--- a/resource_estimation/compile_gateset/compile_gateset_test.py
+++ b/resource_estimation/compile_gateset/compile_gateset_test.py
@@ -30,7 +30,7 @@ def test_compile_cliff_rz_gateset() -> None:
     compiled = compile_gateset(circuit, gateset=CliffRzGateset())
     allowed = cirq.Gateset(cirq.H, cirq.S, cirq.Z, cirq.X, cirq.CNOT, cirq.Rz)
 
-    assert all(op.gate in allowed for op in compiled.all_operations())
+    assert all(op in allowed for op in compiled.all_operations())
 
 
 def test_compile_clifford_t_gateset() -> None:
@@ -40,13 +40,9 @@ def test_compile_clifford_t_gateset() -> None:
     compiled = compile_gateset(circuit, gateset=clifford_t_gateset(atol=1e-3), verbose=False)
     allowed = cirq.Gateset(cirq.H, cirq.S, cirq.Z, cirq.X, cirq.CNOT, cirq.T)
 
-    assert all(op.gate in allowed for op in compiled.all_operations())
+    assert all(op in allowed for op in compiled.all_operations())
 
 
-def test_compile_clifford_t_gateset_requires_atol() -> None:
-    q = cirq.LineQubit(0)
-    circuit = cirq.Circuit(cirq.Rz(rads=pi / 7).on(q))
-    gateset = cirq.Gateset(cirq.H, cirq.S, cirq.Z, cirq.X, cirq.CNOT, cirq.T)
-
-    with pytest.raises(ValueError, match="_atol"):
-        compile_gateset(circuit, gateset=gateset, verbose=False)
+def test_bad_gateset_raises_type_error() -> None:
+    with pytest.raises(TypeError, match="must be CompilationTargetGateset"):
+        _ = compile_gateset(circuit=cirq.Circuit(), gateset=cirq.Gateset(cirq.H, cirq.CNOT))


### PR DESCRIPTION
This is the second PR in a multi-part effort to incorporate type checking into the repo. It primarily adds types to the files in compile_gateset, but it also cleans up a little bit of logic and removes some global variables.