### PR TITLE
Dynamic follow up

### DIFF
--- a/resource_estimation/ftqc/architecture.py
+++ b/resource_estimation/ftqc/architecture.py
@@ -207,24 +207,25 @@ class Architecture(abc.ABC):
 
     ### Fundamental Cost Counting Methods ###
     # These should never be overwritten
-    def gate_cost(self, op: cirq.Operation) -> GateCounts:
+    def gate_cost(self, op: cirq.Operation, **kwargs: bool) -> GateCounts:
+        # May want to alias **kwargs type if in the future there are more different kwargs
         gate_op = _require_gate_operation(op=op)
         try:
-            return self.op_cost[type(gate_op.gate)](gate_op).gate_cost
+            return self.op_cost[type(gate_op.gate)](gate_op, **kwargs).gate_cost
         except KeyError:
             raise ValueError("Gate not recognized")
 
-    def op_time(self, op: cirq.Operation) -> float:
+    def op_time(self, op: cirq.Operation, **kwargs: bool) -> float:
         gate_op = _require_gate_operation(op=op)
         try:
-            return self.op_cost[type(gate_op.gate)](gate_op).op_time
+            return self.op_cost[type(gate_op.gate)](gate_op, **kwargs).op_time
         except KeyError:
             raise ValueError("Gate not recognized")
 
-    def moment_cost(self, op: cirq.Operation) -> GateCounts:
+    def moment_cost(self, op: cirq.Operation, **kwargs: bool) -> GateCounts:
         gate_op = _require_gate_operation(op=op)
         try:
-            return self.op_cost[type(gate_op.gate)](gate_op).moment_cost
+            return self.op_cost[type(gate_op.gate)](gate_op, **kwargs).moment_cost
         except KeyError:
             raise ValueError("Gate not recognized")
 
@@ -624,12 +625,13 @@ class DefaultMovement(Architecture):
         op_time = self.total_time(moment_cost_dict=moment_cost)
         return CostDict(op_time=op_time, moment_cost=moment_cost, gate_cost=gate_cost)
 
-    def correction_cost(self, op: cirq.GateOperation) -> CostDict:
+    def correction_cost(self, op: cirq.GateOperation, **kwargs: bool) -> CostDict:
         if not isinstance(op.gate, lsp.ResourceCorrection):
             raise TypeError("Operation is not an instance of ResourceCorrection")
-        return self._correction_cost(op.gate._resource)
+        dynamic = kwargs.get("dynamic")
+        return self._correction_cost(op.gate._resource, bool(dynamic))
 
-    def _correction_cost(self, resource: Literal["T", "CCZ"]) -> CostDict:
+    def _correction_cost(self, resource: Literal["T", "CCZ"], dynamic: bool) -> CostDict:
         # Total time for CCZ correction: t(H) + t(SE) + t(X) + t(SE) + 3 * t(CNOT) * t(SE) + t(H)
         # (can parallelize H gates, X gates, but 3 pairwise CNOTS means we have to do each one
         # sequentially) This means that the moment cost of this correction is one H moment cost, one
@@ -645,11 +647,11 @@ class DefaultMovement(Architecture):
         # correction
         outcome = randint(0, 1)
         if resource == "T":
-            if outcome:
+            if outcome and dynamic:
                 return CostDict(op_time=0.0, gate_cost={}, moment_cost={})
             else:
                 return self._s_cost
-        if outcome:
+        if outcome and dynamic:
             return CostDict(op_time=0.0, gate_cost={}, moment_cost={})
         else:
             h_gate_cost = collections.Counter(self._h_cost.gate_cost)

--- a/resource_estimation/ftqc/compile_ftqc.py
+++ b/resource_estimation/ftqc/compile_ftqc.py
@@ -18,7 +18,6 @@ import functools
 import os
 import sys
 import time
-from itertools import combinations
 from math import pi
 from typing import TYPE_CHECKING, cast
 
@@ -89,10 +88,7 @@ def _requires_resource(op: cirq.Operation, transversal_cnot: bool) -> bool:
 
 
 def replace_cirq_op(
-    op: cirq.Operation,
-    layout: Layout,
-    transversal_cnot: bool,
-    dynamic: bool = False,
+    op: cirq.Operation, layout: Layout, transversal_cnot: bool, movement: bool = False
 ) -> list[cirq.Operation | cirq.Moment]:
     """Replacement logic similar to decomposition for cirq operations to be converted to primitives.
 
@@ -116,14 +112,14 @@ def replace_cirq_op(
             lsp.Split(partitions=[1] * (len(path_patches[1:])), smooth=False).on(*path_patches[1:]),
         ]
     if _requires_resource(op, transversal_cnot):
-        return teleport_resource(op, layout, dynamic)
+        return teleport_resource(op, layout, movement=movement)
     raise ValueError(
         f"Invalid Op for {'transversal' if transversal_cnot else 'non-transversal'} gate: {op.gate}",
     )
 
 
 def teleport_resource(
-    op: cirq.Operation, layout: Layout, dynamic: bool = False
+    op: cirq.Operation, layout: Layout, movement: bool = False
 ) -> list[cirq.Moment | cirq.Operation]:
     distil_t = layout.distil and op in cirq.GateFamily(cirq.T)
     if not all(isinstance(q, cirq.GridQubit) for q in op.qubits):
@@ -138,11 +134,11 @@ def teleport_resource(
     if distil_t:
         ftype = "t"
         prep_gate = lsp.Distil("T")
-        correction = lsp.ResourceCorrection("T") if dynamic else cirq.S
+        correction = lsp.ResourceCorrection("T") if movement else cirq.S
     elif cultivate_t:
         ftype = "t"
         prep_gate = lsp.Cultivate(pi / 4)
-        correction = lsp.ResourceCorrection("T") if dynamic else cirq.S
+        correction = lsp.ResourceCorrection("T") if movement else cirq.S
     elif cultivate_s:
         ftype = "s"
         prep_gate = lsp.Cultivate(pi / 2)
@@ -150,15 +146,15 @@ def teleport_resource(
     elif distil_ccz:
         ftype = "ccz"
         prep_gate = lsp.Distil("CCZ")
-        if dynamic:
-            correction = lsp.ResourceCorrection("CCZ")
-        else:
-            correction = [
-                *cirq.H.on_each(*op.qubits),
-                *cirq.X.on_each(*op.qubits),
-                *cirq.CNOT.on_each(*combinations(op.qubits, 2)),
-                *cirq.H.on_each(*op.qubits),
-            ]
+        correction = lsp.ResourceCorrection("CCZ")
+        # CCZ distillation is movement-only, update this if that changes
+        # else:
+        #     correction = [
+        #         *cirq.H.on_each(*op.qubits),
+        #         *cirq.X.on_each(*op.qubits),
+        #         *cirq.CNOT.on_each(*combinations(op.qubits, 2)),
+        #         *cirq.H.on_each(*op.qubits),
+        #     ]
     else:
         raise ValueError(f"Invalid resource encountered: {op.gate}")
     available_factories = layout.available_factories(ftype)
@@ -341,7 +337,6 @@ def _decompose_to_primitives(
     circuit: cirq.Circuit,
     layout: Layout,
     arc: Architecture,
-    dynamic: bool = False,
 ) -> cirq.Circuit:
     primitives = cirq.Gateset(
         *(cirq.GateFamily(g._gate, ignore_global_phase=False) for g in arc.primitives.gates),
@@ -350,7 +345,7 @@ def _decompose_to_primitives(
 
     def _map_fn(op: cirq.Operation) -> cirq.OP_TREE:
         return replace_cirq_op(
-            op=op, layout=layout, transversal_cnot=transversal_cnot, dynamic=dynamic
+            op=op, layout=layout, transversal_cnot=transversal_cnot, movement=arc.movement
         )
 
     # TODO: can we turn layout into a decomposition_context?
@@ -413,7 +408,6 @@ def ft_compile(
     verbose: int = 1,
     with_barriers: bool = False,
     skip_validation: bool = False,
-    dynamic: bool = False,
 ) -> cirq.Circuit:
     """Basic read/replace compiler that converts a cirq Circuit over the Clifford + T + CCZ gateset to a cirq circuit of primitives.
     The layout input contains the input circuit and information about any routing that might be necessary during the compilation process.
@@ -432,7 +426,7 @@ def ft_compile(
     else:
         validate_ops(circuit, verbose=verbose)
 
-    circuit = _decompose_to_primitives(circuit, layout=layout, arc=arc, dynamic=dynamic)
+    circuit = _decompose_to_primitives(circuit, layout=layout, arc=arc)
 
     # Handling State Prep
     # In a more optimized world this could happen the moment before the first logical operation

--- a/resource_estimation/ftqc/compile_ftqc_test.py
+++ b/resource_estimation/ftqc/compile_ftqc_test.py
@@ -28,7 +28,7 @@ from resource_estimation.ftqc.layout import (
     MovementDistillery,
     MovementLayout,
 )
-from resource_estimation.typing import GateKey, _require_gate_operation
+from resource_estimation.typing import GateKey
 
 
 @pytest.fixture
@@ -51,17 +51,6 @@ def random_circ() -> cirq.Circuit:
         qubits=5,
         n_moments=8,
         op_density=1,
-        gate_domain={cirq.H: 1, cirq.CNOT: 2, cirq.T: 1, cirq.S: 1},
-        random_state=73,
-    )
-
-
-@pytest.fixture
-def random_circ2() -> cirq.Circuit:
-    return cirq.testing.random_circuit(
-        qubits=4,
-        n_moments=7,
-        op_density=0.8,
         gate_domain={cirq.H: 1, cirq.CNOT: 2, cirq.T: 1, cirq.S: 1},
         random_state=73,
     )
@@ -293,91 +282,91 @@ def test_deterministic_compilation(random_circ: cirq.Circuit) -> None:
     cirq.testing.assert_has_diagram(compiled1, str(compiled2))
 
 
-def test_nondeterministic_compilation_T(random_circ2: cirq.Circuit) -> None:
-    circuit = random_circ2
-    lay = MovementLayout(circuit)
-    arc = arch.DefaultMovement()
-    compiled1 = comp.ft_compile(lay, arc, dynamic=False)
-    compiled2 = comp.ft_compile(lay, arc, dynamic=True)
-    # We expect basically the same operations except that there are ResourceCorrection gates instead
-    # of S gates
-    # Hoping that this is deterministic
-    compiled1_ops = list(compiled1.all_operations())
-    compiled2_ops = list(compiled2.all_operations())
-    assert len(compiled1_ops) == len(compiled2_ops)
-    for i, (op1, op2) in enumerate(zip(compiled1_ops, compiled2_ops)):
-        op1 = _require_gate_operation(op1)
-        op2 = _require_gate_operation(op2)
-        if op1.gate != op2.gate:
-            assert isinstance(op1.gate, cirq.ZPowGate)
-            assert isinstance(op2.gate, lsp.ResourceCorrection)
-            assert op2.gate.resource == "T"
-
-
-def test_nondeterministic_compilation_CCZ() -> None:
-    circuit = cirq.Circuit(
-        cirq.CCZ.on(cirq.GridQubit(0, 0), cirq.GridQubit(0, 1), cirq.GridQubit(0, 2))
-    )
-    lay = MovementDistillery(circuit, num_t_factories=0, num_ccz_factories=1)
-    arc = arch.DefaultMovement()
-    compiled1 = comp.ft_compile(lay, arc, dynamic=False)
-    compiled2 = comp.ft_compile(lay, arc, dynamic=True)
-    # We expect the same operations on the CCZ qubits until there is a ResourceCorrection gate
-    compiled1_ops = list(compiled1.all_operations())
-    compiled2_ops = list(compiled2.all_operations())
-
-    def relevant_op(op: cirq.Operation) -> bool:
-        qubits = op.qubits
-        if (
-            cirq.GridQubit(0, 0) in qubits
-            or cirq.GridQubit(0, 1) in qubits
-            or cirq.GridQubit(0, 2) in qubits
-        ):
-            return True
-        return False
-
-    reached_correction = False
-    moments1 = list(compiled1.moments)
-    moments2 = list(compiled2.moments)
-    correction_circuit = cirq.Circuit()
-    for i in range(0, len(moments1)):
-        # The circuits should be identical until we reach the correction part
-        if not reached_correction:
-            try:
-                assert len(moments1[i].operations) == len(moments2[i].operations)
-            except:
-                reached_correction = True
-                for op in moments1[i].operations:
-                    if relevant_op(op):
-                        assert isinstance(op.gate, cirq.HPowGate)
-                for op in moments2[i].operations:
-                    if relevant_op(op):
-                        assert isinstance(op.gate, lsp.ResourceCorrection)
-                        assert op.gate.resource == "CCZ"
-
-        if not reached_correction:
-            for j in range(0, len(moments2[i].operations)):
-                assert moments1[i].operations[j] == moments2[i].operations[j]
-        else:
-            # Once we reach the correction part, we want to make sure compilation does exactly what
-            # we expect on the logical qubits
-            for op in moments1[i].operations:
-                if relevant_op(op):
-                    correction_circuit.append(op)
-    # If this errors, look at the correction circuit to make sure it's not just that the CNOT order
-    # changed or the qubit indices changes
-    cirq.testing.assert_has_diagram(
-        correction_circuit,
-        textwrap.dedent(
-            """
-        (0, 0): ───H───SE(1)───X───MOVE_IZ───@───MOVE_IZ───SE(1)───MOVE_IZ───@───MOVE_IZ───SE(1)───H─────────SE(1)─────────────────────────────────
-                                             │                               │
-        (0, 1): ───H───SE(1)───X───MOVE_IZ───X───MOVE_IZ───SE(1)───MOVE_IZ───┼───────────────────────────────@───────MOVE_IZ───SE(1)───H───SE(1)───
-                                                                             │                               │
-        (0, 2): ───H───SE(1)───X───MOVE_IZ───────────────────────────────────X───MOVE_IZ───SE(1)───MOVE_IZ───X───────MOVE_IZ───SE(1)───H───SE(1)───
-        """
-        ),
-    )
+# def test_nondeterministic_compilation_T(random_circ2: cirq.Circuit) -> None:
+#     circuit = random_circ2
+#     lay = MovementLayout(circuit)
+#     arc = arch.DefaultMovement()
+#     compiled1 = comp.ft_compile(lay, arc, dynamic=False)
+#     compiled2 = comp.ft_compile(lay, arc, dynamic=True)
+#     # We expect basically the same operations except that there are ResourceCorrection gates instead
+#     # of S gates
+#     # Hoping that this is deterministic
+#     compiled1_ops = list(compiled1.all_operations())
+#     compiled2_ops = list(compiled2.all_operations())
+#     assert len(compiled1_ops) == len(compiled2_ops)
+#     for i, (op1, op2) in enumerate(zip(compiled1_ops, compiled2_ops)):
+#         op1 = _require_gate_operation(op1)
+#         op2 = _require_gate_operation(op2)
+#         if op1.gate != op2.gate:
+#             assert isinstance(op1.gate, cirq.ZPowGate)
+#             assert isinstance(op2.gate, lsp.ResourceCorrection)
+#             assert op2.gate.resource == "T"
+#
+#
+# def test_nondeterministic_compilation_CCZ() -> None:
+#     circuit = cirq.Circuit(
+#         cirq.CCZ.on(cirq.GridQubit(0, 0), cirq.GridQubit(0, 1), cirq.GridQubit(0, 2))
+#     )
+#     lay = MovementDistillery(circuit, num_t_factories=0, num_ccz_factories=1)
+#     arc = arch.DefaultMovement()
+#     compiled1 = comp.ft_compile(lay, arc, dynamic=False)
+#     compiled2 = comp.ft_compile(lay, arc, dynamic=True)
+#     # We expect the same operations on the CCZ qubits until there is a ResourceCorrection gate
+#     compiled1_ops = list(compiled1.all_operations())
+#     compiled2_ops = list(compiled2.all_operations())
+#
+#     def relevant_op(op: cirq.Operation) -> bool:
+#         qubits = op.qubits
+#         if (
+#             cirq.GridQubit(0, 0) in qubits
+#             or cirq.GridQubit(0, 1) in qubits
+#             or cirq.GridQubit(0, 2) in qubits
+#         ):
+#             return True
+#         return False
+#
+#     reached_correction = False
+#     moments1 = list(compiled1.moments)
+#     moments2 = list(compiled2.moments)
+#     correction_circuit = cirq.Circuit()
+#     for i in range(0, len(moments1)):
+#         # The circuits should be identical until we reach the correction part
+#         if not reached_correction:
+#             try:
+#                 assert len(moments1[i].operations) == len(moments2[i].operations)
+#             except:
+#                 reached_correction = True
+#                 for op in moments1[i].operations:
+#                     if relevant_op(op):
+#                         assert isinstance(op.gate, cirq.HPowGate)
+#                 for op in moments2[i].operations:
+#                     if relevant_op(op):
+#                         assert isinstance(op.gate, lsp.ResourceCorrection)
+#                         assert op.gate.resource == "CCZ"
+#
+#         if not reached_correction:
+#             for j in range(0, len(moments2[i].operations)):
+#                 assert moments1[i].operations[j] == moments2[i].operations[j]
+#         else:
+#             # Once we reach the correction part, we want to make sure compilation does exactly what
+#             # we expect on the logical qubits
+#             for op in moments1[i].operations:
+#                 if relevant_op(op):
+#                     correction_circuit.append(op)
+#     # If this errors, look at the correction circuit to make sure it's not just that the CNOT order
+#     # changed or the qubit indices changes
+#     cirq.testing.assert_has_diagram(
+#         correction_circuit,
+#         textwrap.dedent(
+#             """
+#         (0, 0): ───H───SE(1)───X───MOVE_IZ───@───MOVE_IZ───SE(1)───MOVE_IZ───@───MOVE_IZ───SE(1)───H─────────SE(1)─────────────────────────────────
+#                                              │                               │
+#         (0, 1): ───H───SE(1)───X───MOVE_IZ───X───MOVE_IZ───SE(1)───MOVE_IZ───┼───────────────────────────────@───────MOVE_IZ───SE(1)───H───SE(1)───
+#                                                                              │                               │
+#         (0, 2): ───H───SE(1)───X───MOVE_IZ───────────────────────────────────X───MOVE_IZ───SE(1)───MOVE_IZ───X───────MOVE_IZ───SE(1)───H───SE(1)───
+#         """
+#         ),
+#     )
 
 
 def test_other_passes(random_circ: cirq.Circuit) -> None:
@@ -669,13 +658,13 @@ def test_t_movement_FF(t_circuit: cirq.Circuit) -> None:
         compiled_t_circuit,
         textwrap.dedent(
             """
-            (0, 0): ───SE(1)─────────H───MOVE───@───#2───────────────────────────────────────────────────────
-                                         │      │   │
-            (0, 1): ───SE(1)─────────────#2─────X───MOVE───#2─────X───MOVE───S───────────────────────────────
-                                                           │      │   │
-            (1, 0): ───CULT(0.785)─────────────────────────┼──────┼───┼──────────────────────────────────────
-                                                           │      │   │
-            (1, 1): ───CULT(0.785)─────────────────────────MOVE───@───#2─────MOVE_MZ───M('')───MOVE_MZ───R───
+       (0, 0): ───SE(1)─────────H───MOVE───@───#2─────────────────────────────────────────────────────────────────────
+                                    │      │   │
+       (0, 1): ───SE(1)─────────────#2─────X───MOVE───#2─────X───MOVE───ResourceCorrection(T)─────────────────────────
+                                                      │      │   │
+       (1, 0): ───CULT(0.785)─────────────────────────┼──────┼───┼────────────────────────────────────────────────────
+                                                      │      │   │
+       (1, 1): ───CULT(0.785)─────────────────────────MOVE───@───#2─────MOVE_MZ─────────────────M('')───MOVE_MZ───R───
             """,
         ),
     )
@@ -697,13 +686,13 @@ def test_t_movement_FT(t_circuit: cirq.Circuit) -> None:
         compiled_t_circuit,
         textwrap.dedent(
             """
-            (0, 0): ───SE(1)─────────H───SE(1)───MOVE───@───#2─────SE(1)─────────────────────────────────────────────────────────────────────
-                                                 │      │   │
-            (0, 1): ───SE(1)─────────────────────#2─────X───MOVE───SE(1)───#2─────X───MOVE───SE(1)───S─────────SE(1)─────────────────────────
-                                                                           │      │   │
-            (1, 0): ───CULT(0.785)─────────────────────────────────────────┼──────┼───┼──────────────────────────────────────────────────────
-                                                                           │      │   │
-            (1, 1): ───CULT(0.785)─────────────────────────────────────────MOVE───@───#2─────SE(1)───MOVE_MZ───M('')───MOVE_MZ───SE(1)───R───
+       (0, 0): ───SE(1)─────────H───SE(1)───MOVE───@───#2─────SE(1)───────────────────────────────────────────────────────────────────────────────────
+                                            │      │   │
+       (0, 1): ───SE(1)─────────────────────#2─────X───MOVE───SE(1)───#2─────X───MOVE───SE(1)───ResourceCorrection(T)───SE(1)─────────────────────────
+                                                                      │      │   │
+       (1, 0): ───CULT(0.785)─────────────────────────────────────────┼──────┼───┼────────────────────────────────────────────────────────────────────
+                                                                      │      │   │
+       (1, 1): ───CULT(0.785)─────────────────────────────────────────MOVE───@───#2─────SE(1)───MOVE_MZ─────────────────M('')───MOVE_MZ───SE(1)───R───
             """,
         ),
     )
@@ -726,14 +715,13 @@ def test_t_movement_TF(t_circuit: cirq.Circuit) -> None:
         compiled_t_circuit,
         textwrap.dedent(
             """
-            (0, 0): ───SE(1)─────────H───────MOVE────@───────#2──────SE(1)───SE(1)───SE(1)───────────────────────────────────
-                                             │       │       │
-            (0, 1): ───SE(1)─────────SE(1)───#2──────X───────MOVE────#2──────X───────MOVE────S─────────SE(1)─────────────────
-                                                                     │       │       │
-            (1, 0): ───CULT(0.785)───SE(1)───SE(1)───SE(1)───SE(1)───┼───────┼───────┼───────────────────────────────────────
-                                                                     │       │       │
-            (1, 1): ───CULT(0.785)───SE(1)───────────────────────────MOVE────@───────#2──────MOVE_MZ───M('')───MOVE_MZ───R───
-
+       (0, 0): ───SE(1)─────────H───────MOVE────@───────#2──────SE(1)───SE(1)───SE(1)─────────────────────────────────────────────────
+                                        │       │       │
+       (0, 1): ───SE(1)─────────SE(1)───#2──────X───────MOVE────#2──────X───────MOVE────ResourceCorrection(T)───SE(1)─────────────────
+                                                                │       │       │
+       (1, 0): ───CULT(0.785)───SE(1)───SE(1)───SE(1)───SE(1)───┼───────┼───────┼─────────────────────────────────────────────────────
+                                                                │       │       │
+       (1, 1): ───CULT(0.785)───SE(1)───────────────────────────MOVE────@───────#2──────MOVE_MZ─────────────────M('')───MOVE_MZ───R───
             """,
         ),
     )
@@ -757,15 +745,16 @@ def test_t_movement_TT(t_circuit: cirq.Circuit) -> None:
         compiled_t_circuit,
         textwrap.dedent(
             """
-                                                                                     ┌──────────┐   ┌──────────┐
-            (0, 0): ───SE(1)─────────H───────SE(1)───MOVE────@───────#2──────SE(1)────SE(1)──────────SE(1)─────────SE(1)───SE(1)───SE(1)───────────────────────────────────
-                                                     │       │       │
-            (0, 1): ───SE(1)─────────SE(1)───SE(1)───#2──────X───────MOVE────SE(1)────#2─────────────X─────────────MOVE────SE(1)───S─────────SE(1)───SE(1)─────────────────
-                                                                                      │              │             │
-            (1, 0): ───CULT(0.785)───SE(1)───SE(1)───SE(1)───SE(1)───SE(1)───SE(1)────┼────SE(1)─────┼────SE(1)────┼───────────────────────────────────────────────────────
-                                                                                      │              │             │
-            (1, 1): ───CULT(0.785)───SE(1)───SE(1)───SE(1)────────────────────────────MOVE───────────@─────────────#2──────SE(1)───MOVE_MZ───M('')───MOVE_MZ───SE(1)───R───
-                                                                                     └──────────┘   └──────────┘
+                                                                                ┌──────────┐   ┌──────────┐
+       (0, 0): ───SE(1)─────────H───────SE(1)───MOVE────@───────#2──────SE(1)────SE(1)──────────SE(1)─────────SE(1)───SE(1)───SE(1)─────────────────────────────────────────────────
+                                                │       │       │
+       (0, 1): ───SE(1)─────────SE(1)───SE(1)───#2──────X───────MOVE────SE(1)────#2─────────────X─────────────MOVE────SE(1)───ResourceCorrection(T)───SE(1)───SE(1)─────────────────
+                                                                                 │              │             │
+       (1, 0): ───CULT(0.785)───SE(1)───SE(1)───SE(1)───SE(1)───SE(1)───SE(1)────┼────SE(1)─────┼────SE(1)────┼─────────────────────────────────────────────────────────────────────
+                                                                                 │              │             │
+       (1, 1): ───CULT(0.785)───SE(1)───SE(1)───SE(1)────────────────────────────MOVE───────────@─────────────#2──────SE(1)───MOVE_MZ─────────────────M('')───MOVE_MZ───SE(1)───R───
+                                                                                └──────────┘   └──────────┘
+
             """,
         ),
     )
@@ -1064,7 +1053,9 @@ def test_replace_cirq_op_distil_ccz(random_circ: cirq.Circuit) -> None:
     op_to_replace = cirq.CCZ.on(cirq.GridQubit(0, 0), cirq.GridQubit(0, 1), cirq.GridQubit(0, 2))
     returned_ops = list(
         cirq.flatten_to_ops(
-            comp.replace_cirq_op(op=op_to_replace, layout=distillery_layout, transversal_cnot=True)
+            comp.replace_cirq_op(
+                op=op_to_replace, layout=distillery_layout, transversal_cnot=True, movement=True
+            )
         )
     )
     # We flatten them here to be explicit about the order the operations should be in
@@ -1074,10 +1065,11 @@ def test_replace_cirq_op_distil_ccz(random_circ: cirq.Circuit) -> None:
         *([cirq.CNOT] * 3),
         *([cirq.MeasurementGate] * 3),
         *([cirq.ResetChannel] * 3),
-        *([cirq.H] * 3),
-        *([cirq.X] * 3),
-        *([cirq.CNOT] * 3),
-        *([cirq.H] * 3),
+        *([lsp.ResourceCorrection("CCZ")]),
+        # *([cirq.H] * 3),
+        # *([cirq.X] * 3),
+        # *([cirq.CNOT] * 3),
+        # *([cirq.H] * 3),
     ]
     assert len(expected_types) == len(ops_flattened)
     for op, expected_type in zip(ops_flattened, expected_types):

--- a/resource_estimation/ftqc/estimate_test.py
+++ b/resource_estimation/ftqc/estimate_test.py
@@ -278,20 +278,25 @@ def test_dynamic_T_resource_counts(mock_randint: mock.MagicMock) -> None:
     qubit = cirq.GridQubit(0, 0)
     static_correction = cirq.S.on(qubit)
     dynamic_correction = lsp.ResourceCorrection("T").on(qubit)
-    mock_randint.side_effect = [1, 0, 1, 0]
+    mock_randint.side_effect = [1, 0, 1, 0, 1, 1]
     static_s_gate_cost = arc.gate_cost(static_correction)
-    assert arc.gate_cost(dynamic_correction) == {}
+    assert arc.gate_cost(dynamic_correction, dynamic=True) == {}
     assert arc.gate_cost(static_correction) == static_s_gate_cost
 
-    assert arc.gate_cost(dynamic_correction) == static_s_gate_cost
+    assert arc.gate_cost(dynamic_correction, dynamic=True) == static_s_gate_cost
     assert arc.gate_cost(static_correction) == static_s_gate_cost
 
     static_correction_time = arc.op_time(static_correction)
-    assert arc.op_time(dynamic_correction) == 0.0
+    assert arc.op_time(dynamic_correction, dynamic=True) == 0.0
     assert arc.op_time(static_correction) == static_correction_time
 
-    assert arc.op_time(dynamic_correction) == static_correction_time
+    assert arc.op_time(dynamic_correction, dynamic=True) == static_correction_time
     assert arc.op_time(static_correction) == static_correction_time
+
+    # If we disable dynamic counts, even when the "roll" is says we don't have to do the gate we
+    # actually still do.
+    assert arc.op_time(dynamic_correction, dynamic=False) == static_correction_time
+    assert arc.gate_cost(dynamic_correction, dynamic=False) == static_s_gate_cost
 
 
 @mock.patch("resource_estimation.ftqc.architecture.randint")
@@ -314,27 +319,35 @@ def test_dynamic_CCZ_resource_counts(mock_randint: mock.MagicMock) -> None:
     correction_circuit.append(se_gate.on_each(*(qubit_b, qubit_c)))
     correction_circuit.append(cirq.H.on_each(*(qubit_a, qubit_b, qubit_c)))
     dynamic_op: cirq.Operation = lsp.ResourceCorrection("CCZ").on(qubit_a, qubit_b, qubit_c)
-    mock_randint.side_effect = [1, 0, 1, 0, 1, 0]
+    mock_randint.side_effect = [1, 0, 1, 0, 1, 0, 1, 1]
     est = ResourceEstimator(arc)
     normal_correction_cost = est.serial_circuit_cost(correction_circuit)
-    operation_dynamic_cost = arc.gate_cost(dynamic_op)
+    operation_dynamic_cost = arc.gate_cost(dynamic_op, dynamic=True)
     assert {} == operation_dynamic_cost
     # Should be correction applied on second flip
-    operation_dynamic_cost = arc.gate_cost(dynamic_op)
+    operation_dynamic_cost = arc.gate_cost(dynamic_op, dynamic=True)
     assert normal_correction_cost == operation_dynamic_cost
 
     normal_correction_time = est.parallel_circuit_time(correction_circuit)
-    operation_dynamic_time = arc.op_time(dynamic_op)
+    operation_dynamic_time = arc.op_time(dynamic_op, dynamic=True)
     assert 0.0 == operation_dynamic_time
-    operation_dynamic_time = arc.op_time(dynamic_op)
+    operation_dynamic_time = arc.op_time(dynamic_op, dynamic=True)
     assert isclose(normal_correction_time, operation_dynamic_time)
 
     parallel_correction_cost = est.parallel_circuit_cost(correction_circuit)
-    moment_dynamic_cost = arc.moment_cost(dynamic_op)
+    moment_dynamic_cost = arc.moment_cost(dynamic_op, dynamic=True)
     assert {} == moment_dynamic_cost
     # Should be correction applied on second flip
-    moment_dynamic_cost = arc.moment_cost(dynamic_op)
+    moment_dynamic_cost = arc.moment_cost(dynamic_op, dynamic=True)
     assert parallel_correction_cost == moment_dynamic_cost
+
+    # dynamic=False overrides the fact that we happen to flip 1 here
+    moment_dynamic_cost = arc.moment_cost(dynamic_op, dynamic=False)
+    assert parallel_correction_cost == moment_dynamic_cost
+
+    # dynamic=False overrides the fact that we happen to flip 1 here
+    moment_dynamic_cost = arc.gate_cost(dynamic_op, dynamic=False)
+    assert normal_correction_cost == operation_dynamic_cost
 
 
 def test_physical_qubit_count(lattice_estimator: est.ResourceEstimator) -> None:

--- a/resource_estimation/ftqc/lattice_surgery_primitives_test.py
+++ b/resource_estimation/ftqc/lattice_surgery_primitives_test.py
@@ -90,8 +90,10 @@ def test_distil() -> None:
 def test_resource_correct() -> None:
     gate = lsp.ResourceCorrection("T")
     assert str(gate) == "ResourceCorrection(T)"
+    assert gate.resource == "T"
     gate = lsp.ResourceCorrection("CCZ")
     assert str(gate) == "ResourceCorrection(CCZ)"
+    assert gate.resource == "CCZ"
     # Checking an invalid resource necessitates ignoring the Literals in the argument
     with pytest.raises(ValueError, match="Invalid resource"):
         _ = lsp.ResourceCorrection("Toffoli")  # type: ignore[arg-type]


### PR DESCRIPTION
This follows up on parts of the previous dynamic PR, namely removing the dynamic flag from the compiler and making it a part of the estimation, so a movement architecture will always compile with `ResourceCorrection` gates but you can pass a flag when estimating the resources to make that deterministic instead of dynamic.

I would still like to update the CCZ correction circuits but haven't found a good reference for exactly how the other circuits are structured yet. Also, I think this PR and more-granular-movement make a case for possibly refactoring estimate.py and the way it interacts with the cost functions in Architecture. I haven't made this change yet on this branch, but it looks like we will have to add **kwargs to every single cost function even though most of them don't actually use it which will be somewhat annoying.